### PR TITLE
Add Python trajectory analysis utilities

### DIFF
--- a/python/trajstat_py/__init__.py
+++ b/python/trajstat_py/__init__.py
@@ -1,0 +1,14 @@
+"""Python implementations of TrajStat statistical analyses."""
+
+from .trajectory_cluster import TrajectoryClusterer
+from .pscf import GridDefinition, PSCFCalculator, PSCFResult
+from .cwt import CWTCalculator, CWTResult
+
+__all__ = [
+    "TrajectoryClusterer",
+    "GridDefinition",
+    "PSCFCalculator",
+    "PSCFResult",
+    "CWTCalculator",
+    "CWTResult",
+]

--- a/python/trajstat_py/cwt.py
+++ b/python/trajstat_py/cwt.py
@@ -1,0 +1,91 @@
+"""Concentration Weighted Trajectory (CWT) implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .pscf import GridDefinition
+
+__all__ = ["CWTCalculator", "CWTResult"]
+
+
+@dataclass
+class CWTResult:
+    nij: np.ndarray
+    sum_values: np.ndarray
+    cwt: np.ndarray
+
+
+class CWTCalculator:
+    """Calculate CWT values on a regular analysis grid."""
+
+    def __init__(
+        self,
+        grid: GridDefinition,
+        trajectories: Iterable[Sequence[Sequence[float]]],
+        measurements: Sequence[float],
+        *,
+        missing_value: float = np.nan,
+    ) -> None:
+        self.grid = grid
+        self.trajectories = [np.asarray(traj, dtype=float) for traj in trajectories]
+        self.measurements = np.asarray(measurements, dtype=float)
+        if len(self.trajectories) != len(self.measurements):
+            raise ValueError("Each trajectory must have an associated measurement value.")
+        self.missing_value = missing_value
+
+    def compute(self, *, altitude_threshold: Optional[float] = None) -> CWTResult:
+        nij = np.zeros(self.grid.shape, dtype=int)
+        sums = np.zeros_like(nij, dtype=float)
+
+        for traj, value in zip(self.trajectories, self.measurements):
+            if self._is_missing(value):
+                continue
+            for point in traj:
+                if altitude_threshold is not None and point.shape[0] >= 3 and point[2] > altitude_threshold:
+                    continue
+                ix, iy = self._point_to_index(point)
+                if ix is None:
+                    continue
+                nij[iy, ix] += 1
+                sums[iy, ix] += value
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            cwt = np.divide(sums, nij, out=np.zeros_like(sums), where=nij > 0)
+        return CWTResult(nij=nij, sum_values=sums, cwt=cwt)
+
+    def apply_weighting(
+        self,
+        data: np.ndarray,
+        *,
+        thresholds: Sequence[int],
+        weights: Sequence[float],
+        counts: np.ndarray,
+    ) -> np.ndarray:
+        from .pscf import PSCFCalculator
+
+        return PSCFCalculator.apply_weighting(
+            data,
+            thresholds=thresholds,
+            weights=weights,
+            counts=counts,
+        )
+
+    def _point_to_index(self, point: Sequence[float]) -> Tuple[Optional[int], Optional[int]]:
+        x, y = point[0], point[1]
+        if not (self.grid.x_min <= x < self.grid.x_max and self.grid.y_min <= y < self.grid.y_max):
+            return None, None
+        ix = int((x - self.grid.x_min) / self.grid.cell_size)
+        iy = int((y - self.grid.y_min) / self.grid.cell_size)
+        ny, nx = self.grid.shape
+        if 0 <= ix < nx and 0 <= iy < ny:
+            return ix, iy
+        return None, None
+
+    def _is_missing(self, value: float) -> bool:
+        if np.isnan(self.missing_value):
+            return np.isnan(value)
+        return float(value) == float(self.missing_value)

--- a/python/trajstat_py/pscf.py
+++ b/python/trajstat_py/pscf.py
@@ -1,0 +1,164 @@
+"""Potential Source Contribution Function (PSCF) implementation.
+
+The routines below port the logic that powers the Java based PSCF dialog to a
+pure Python workflow.  They operate on regular rectilinear grids and work with
+arbitrary trajectory collections that include measurement data associated with
+an entire trajectory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+
+__all__ = ["GridDefinition", "PSCFCalculator", "PSCFResult"]
+
+
+@dataclass(frozen=True)
+class GridDefinition:
+    """Describe a regular analysis grid."""
+
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float
+    cell_size: float
+
+    @property
+    def x_edges(self) -> np.ndarray:
+        return np.arange(self.x_min, self.x_max + self.cell_size, self.cell_size)
+
+    @property
+    def y_edges(self) -> np.ndarray:
+        return np.arange(self.y_min, self.y_max + self.cell_size, self.cell_size)
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        nx = int(np.ceil((self.x_max - self.x_min) / self.cell_size))
+        ny = int(np.ceil((self.y_max - self.y_min) / self.cell_size))
+        return ny, nx
+
+
+@dataclass
+class PSCFResult:
+    nij: np.ndarray
+    mij: np.ndarray
+    pscf: np.ndarray
+    traj_counts: np.ndarray
+
+
+class PSCFCalculator:
+    """Calculate PSCF statistics from trajectory end points."""
+
+    def __init__(
+        self,
+        grid: GridDefinition,
+        trajectories: Iterable[Sequence[Sequence[float]]],
+        measurements: Sequence[float],
+        *,
+        missing_value: float = np.nan,
+    ) -> None:
+        self.grid = grid
+        self.trajectories = [np.asarray(traj, dtype=float) for traj in trajectories]
+        self.measurements = np.asarray(measurements, dtype=float)
+        if len(self.trajectories) != len(self.measurements):
+            raise ValueError("Each trajectory must have an associated measurement value.")
+        self.missing_value = missing_value
+
+    # ------------------------------------------------------------------
+    def compute(
+        self,
+        threshold: float,
+        *,
+        altitude_threshold: Optional[float] = None,
+    ) -> PSCFResult:
+        """Compute Nij, Mij and the PSCF field."""
+
+        nij, traj_counts = self._count_endpoints(altitude_threshold=altitude_threshold)
+        mij, _ = self._count_endpoints(
+            threshold=threshold,
+            altitude_threshold=altitude_threshold,
+        )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            pscf = np.divide(mij, nij, out=np.zeros_like(mij, dtype=float), where=nij > 0)
+        return PSCFResult(nij=nij, mij=mij, pscf=pscf, traj_counts=traj_counts)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def apply_weighting(
+        data: np.ndarray,
+        *,
+        thresholds: Sequence[int],
+        weights: Sequence[float],
+        counts: np.ndarray,
+    ) -> np.ndarray:
+        """Apply the empirical weighting scheme used by TrajStat."""
+
+        if len(thresholds) != len(weights):
+            raise ValueError("thresholds and weights must have the same length.")
+        thresholds = np.asarray(thresholds, dtype=int)
+        weights = np.asarray(weights, dtype=float)
+
+        result = data.astype(float).copy()
+        flat_counts = counts.ravel()
+        flat_data = result.ravel()
+        for i, count in enumerate(flat_counts):
+            weight = 1.0
+            for idx, threshold in enumerate(thresholds):
+                if idx == len(thresholds) - 1:
+                    if count <= threshold:
+                        weight = weights[idx]
+                        break
+                else:
+                    if thresholds[idx + 1] < count <= threshold:
+                        weight = weights[idx]
+                        break
+            flat_data[i] *= weight
+        return flat_data.reshape(result.shape)
+
+    # ------------------------------------------------------------------
+    def _count_endpoints(
+        self,
+        *,
+        threshold: Optional[float] = None,
+        altitude_threshold: Optional[float] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        counts = np.zeros(self.grid.shape, dtype=int)
+        traj_counts = np.zeros_like(counts)
+
+        for traj, value in zip(self.trajectories, self.measurements):
+            if self._is_missing(value):
+                continue
+            if threshold is not None and value < threshold:
+                continue
+
+            visited = set()
+            for point in traj:
+                if altitude_threshold is not None and point.shape[0] >= 3 and point[2] > altitude_threshold:
+                    continue
+                ix, iy = self._point_to_index(point)
+                if ix is None:
+                    continue
+                counts[iy, ix] += 1
+                if (iy, ix) not in visited:
+                    traj_counts[iy, ix] += 1
+                    visited.add((iy, ix))
+        return counts, traj_counts
+
+    def _point_to_index(self, point: Sequence[float]) -> Tuple[Optional[int], Optional[int]]:
+        x, y = point[0], point[1]
+        if not (self.grid.x_min <= x < self.grid.x_max and self.grid.y_min <= y < self.grid.y_max):
+            return None, None
+        ix = int((x - self.grid.x_min) / self.grid.cell_size)
+        iy = int((y - self.grid.y_min) / self.grid.cell_size)
+        ny, nx = self.grid.shape
+        if 0 <= ix < nx and 0 <= iy < ny:
+            return ix, iy
+        return None, None
+
+    def _is_missing(self, value: float) -> bool:
+        if np.isnan(self.missing_value):
+            return np.isnan(value)
+        return float(value) == float(self.missing_value)

--- a/python/trajstat_py/trajectory_cluster.py
+++ b/python/trajstat_py/trajectory_cluster.py
@@ -1,0 +1,199 @@
+"""Clustering utilities for back trajectory analyses.
+
+This module rewrites the Java based clustering logic used by TrajStat into
+pure Python code.  The :class:`TrajectoryClusterer` class provides a minimal
+k-means implementation that works with evenly sampled trajectories and can be
+used to reproduce the cluster statistics produced by the desktop
+application.  The implementation also exposes helpers to compute the cluster
+mean trajectories and total spatial variance (TSV) using both Euclidean and
+angular distance metrics, mirroring the original Java algorithms.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+__all__ = ["TrajectoryClusterer"]
+
+
+class TrajectoryClusterer:
+    """Cluster back trajectories using a simple k-means implementation.
+
+    Parameters
+    ----------
+    trajectories:
+        Iterable of trajectories.  Each trajectory must be convertible to a
+        ``numpy.ndarray`` of shape ``(n_points, n_dimensions)``.  The clusterer
+        assumes that every trajectory contains the same number of sampled
+        points, which matches the behaviour of the original TrajStat code.
+
+    Attributes
+    ----------
+    centroids_:
+        Array with shape ``(n_clusters, n_points, n_dimensions)`` containing the
+        cluster centroids (mean trajectories).
+    labels_:
+        Cluster index assigned to every trajectory.
+    """
+
+    def __init__(self, trajectories: Iterable[Sequence[Sequence[float]]]):
+        trajs = [np.asarray(traj, dtype=float) for traj in trajectories]
+        if not trajs:
+            raise ValueError("At least one trajectory is required.")
+
+        lengths = {traj.shape for traj in trajs}
+        if len(lengths) != 1:
+            raise ValueError("All trajectories must have the same shape.")
+
+        self._trajectories = np.stack(trajs, axis=0)
+        self._n_samples, self._n_points, self._n_dims = self._trajectories.shape
+        self.centroids_: Optional[np.ndarray] = None
+        self.labels_: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    # Fitting
+    # ------------------------------------------------------------------
+    def fit(
+        self,
+        n_clusters: int,
+        *,
+        max_iter: int = 100,
+        tol: float = 1e-4,
+        random_state: Optional[int] = None,
+    ) -> "TrajectoryClusterer":
+        """Run k-means on the trajectory set.
+
+        The algorithm clusters flattened trajectory coordinates.  Although
+        simple, this mirrors the original workflow where the spatial variance
+        is measured using Euclidean or angular metrics after clustering.
+
+        Parameters
+        ----------
+        n_clusters:
+            Number of clusters to form.
+        max_iter:
+            Maximum number of k-means iterations.
+        tol:
+            Convergence tolerance based on centroid displacement.
+        random_state:
+            Optional seed for deterministic initial centroid selection.
+        """
+
+        if n_clusters <= 1:
+            raise ValueError("n_clusters must be greater than 1.")
+        if n_clusters > self._n_samples:
+            raise ValueError("n_clusters must be <= number of trajectories.")
+
+        rng = np.random.default_rng(random_state)
+        flat_trajs = self._trajectories.reshape(self._n_samples, -1)
+
+        # Initialise centroids using a simple random choice without replacement
+        # to stay dependency-free.
+        indices = rng.choice(self._n_samples, size=n_clusters, replace=False)
+        centroids = flat_trajs[indices]
+
+        labels = np.zeros(self._n_samples, dtype=int)
+        for _ in range(max_iter):
+            distances = np.linalg.norm(flat_trajs[:, None, :] - centroids[None, :, :], axis=2)
+            new_labels = distances.argmin(axis=1)
+
+            new_centroids = np.empty_like(centroids)
+            for k in range(n_clusters):
+                members = flat_trajs[new_labels == k]
+                if members.size == 0:
+                    # Reinitialise empty clusters using a random trajectory.
+                    new_centroids[k] = flat_trajs[rng.integers(self._n_samples)]
+                else:
+                    new_centroids[k] = members.mean(axis=0)
+
+            shift = np.linalg.norm(new_centroids - centroids)
+            centroids = new_centroids
+            labels = new_labels
+            if shift < tol:
+                break
+
+        self.centroids_ = centroids.reshape(n_clusters, self._n_points, self._n_dims)
+        self.labels_ = labels
+        return self
+
+    # ------------------------------------------------------------------
+    # Derived statistics
+    # ------------------------------------------------------------------
+    def mean_trajectories(self) -> np.ndarray:
+        """Return the mean trajectory for every cluster."""
+
+        self._ensure_fitted()
+        assert self.centroids_ is not None
+        return self.centroids_.copy()
+
+    def cluster_sizes(self) -> np.ndarray:
+        """Return the number of trajectories contained in every cluster."""
+
+        self._ensure_fitted()
+        assert self.labels_ is not None
+        counts = np.bincount(self.labels_, minlength=self.centroids_.shape[0])
+        return counts.astype(int)
+
+    def cluster_ratios(self) -> np.ndarray:
+        """Return the fraction of trajectories assigned to every cluster."""
+
+        counts = self.cluster_sizes()
+        return counts / counts.sum()
+
+    # ------------------------------------------------------------------
+    # Total spatial variance
+    # ------------------------------------------------------------------
+    def total_spatial_variance(self, metric: str = "euclidean") -> float:
+        """Compute the TSV of the clustering using the requested metric."""
+
+        self._ensure_fitted()
+        assert self.labels_ is not None and self.centroids_ is not None
+
+        metric = metric.lower()
+        if metric not in {"euclidean", "angle"}:
+            raise ValueError("metric must be 'euclidean' or 'angle'.")
+
+        variance = 0.0
+        for idx, traj in enumerate(self._trajectories):
+            centroid = self.centroids_[self.labels_[idx]]
+            if metric == "euclidean":
+                variance += self._euclidean_distance(traj, centroid)
+            else:
+                variance += self._angle_distance(traj, centroid)
+        return variance
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_fitted(self) -> None:
+        if self.centroids_ is None or self.labels_ is None:
+            raise RuntimeError("Call 'fit' before requesting cluster statistics.")
+
+    @staticmethod
+    def _euclidean_distance(traj_a: np.ndarray, traj_b: np.ndarray) -> float:
+        diff = (traj_a - traj_b)[..., :2]
+        return float(np.sqrt(np.sum(diff ** 2)))
+
+    @staticmethod
+    def _angle_distance(traj_a: np.ndarray, traj_b: np.ndarray) -> float:
+        # The Java implementation ignores the vertical coordinate and compares
+        # the horizontal components of the trajectories.
+        xy_a = traj_a[:, :2]
+        xy_b = traj_b[:, :2]
+        x0, y0 = xy_a[0]
+        angles = []
+        for point_a, point_b in zip(xy_a[1:], xy_b[1:]):
+            a = np.sum((point_a - (x0, y0)) ** 2)
+            b = np.sum((point_b - (x0, y0)) ** 2)
+            c = np.sum((point_b - point_a) ** 2)
+            if a == 0 or b == 0:
+                cosine = 0.0
+            else:
+                cosine = 0.5 * (a + b - c) / np.sqrt(a * b)
+                cosine = float(np.clip(cosine, -1.0, 1.0))
+            angles.append(np.arccos(cosine))
+        if not angles:
+            return 0.0
+        return float(np.sum(angles) / xy_a.shape[0])


### PR DESCRIPTION
## Summary
- add a `TrajectoryClusterer` to offer a NumPy based clustering workflow for trajectories
- provide PSCF and CWT calculators that accept measurement data and reproduce the TrajStat analyses
- expose the new helpers through a lightweight `trajstat_py` package entry point

## Testing
- python -m compileall python/trajstat_py

------
https://chatgpt.com/codex/tasks/task_b_68e32cddf6bc83299680585c91e458a1